### PR TITLE
fix: Using rowScan before defer cancel()

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -127,16 +127,16 @@ func RowsClose(rows *sql.Rows, err error) error {
 }
 
 // GetRow execute single row query
-func GetRow(ctx context.Context, db *sql.DB, query string, args ...interface{}) *sql.Row {
+func GetRow(ctx context.Context, db *sql.DB, scanner func(RowScanner) error, query string, args ...interface{}) error {
 	tx := ReadTx(ctx)
 
 	ctx, cancel := context.WithTimeout(ctx, SQLTimeout)
 	defer cancel()
 
 	if tx != nil {
-		return tx.QueryRowContext(ctx, query, args...)
+		return scanner(tx.QueryRowContext(ctx, query, args...))
 	}
-	return db.QueryRowContext(ctx, query, args...)
+	return scanner(db.QueryRowContext(ctx, query, args...))
 }
 
 // Create execute query with a RETURNING id

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -192,7 +192,10 @@ func TestGetRow(t *testing.T) {
 			}
 
 			var got uint64
-			gotErr := GetRow(ctx, mockDb, "SELECT id FROM item WHERE id = $1", 1).Scan(&got)
+			testScanItem := func(row RowScanner) error {
+				return row.Scan(&got)
+			}
+			gotErr := GetRow(ctx, mockDb, testScanItem, "SELECT id FROM item WHERE id = $1", 1)
 
 			failed := false
 


### PR DESCRIPTION
https://github.com/golang/go/issues/28842