### PR TITLE
refactor(redis): add format

### DIFF
--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -40,7 +40,7 @@ type Config struct {
 
 func Flags(fs *flag.FlagSet, prefix string, overrides ...flags.Override) Config {
 	return Config{
-		address:  flags.String(fs, prefix, "redis", "Address", "Redis Address (blank to disable)", "localhost:6379", overrides),
+		address:  flags.String(fs, prefix, "redis", "Address", "Redis Address fqdn:port (blank to disable)", "localhost:6379", overrides),
 		username: flags.String(fs, prefix, "redis", "Username", "Redis Username, if any", "", overrides),
 		password: flags.String(fs, prefix, "redis", "Password", "Redis Password, if any", "", overrides),
 		database: flags.Int(fs, prefix, "redis", "Database", "Redis Database", 0, overrides),


### PR DESCRIPTION
Hi,

Just to clarify in fibr the usage, because some others tools need "redis://"